### PR TITLE
feat: handle change company requests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,8 @@
 APPLICATION_HOST=192.168.0.1
 FIDC_FQDN=idam.amido.aws.chdev.org
 FIDC_REALM=alpha
+FIDC_LOGIN_JOURNEY=CHWebFiling
 OIDC_CLIENT_ID=fidc_client
 OIDC_CLIENT_SECRET=password
+UI_LOGIN_URL=https://idam-ui.amido.aws.chdev.org/account/login/
 DOCKER_IMAGE=ig-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./nginx/ewf-kermit.companieshouse.gov.uk.crt:/etc/nginx/ewf-kermit.companieshouse.gov.uk.crt
       - ./nginx/ewf-kermit.companieshouse.gov.uk.key:/etc/nginx/ewf-kermit.companieshouse.gov.uk.key
     ports:
+      - 80:80
       - 443:443
     restart: always
 
@@ -17,8 +18,10 @@ services:
       - APPLICATION_HOST=${APPLICATION_HOST}
       - FIDC_FQDN=${FIDC_FQDN}
       - FIDC_REALM=${FIDC_REALM}
+      - FIDC_LOGIN_JOURNEY=${FIDC_LOGIN_JOURNEY}
       - OIDC_CLIENT_ID=${OIDC_CLIENT_ID}
       - OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET}
+      - UI_LOGIN_URL=${UI_LOGIN_URL}
     build:
       context: ./webfiling
       args:

--- a/terraform/groups/identity-gateway/main.tf
+++ b/terraform/groups/identity-gateway/main.tf
@@ -59,7 +59,9 @@ module "webfiling" {
   application_host        = replace(var.application_url, "https://", "")
   fidc_fqdn               = replace(var.fidc_custom_url, "https://", "")
   fidc_realm              = var.fidc_realm
+  fidc_login_journey      = var.fidc_login_journey
   oidc_client_id          = var.oidc_client_id
   oidc_client_secret      = var.oidc_client_secret
+  ui_login_url            = var.ui_login_url
   tags                    = local.common_tags
 }

--- a/terraform/groups/identity-gateway/modules/ecs-task/main.tf
+++ b/terraform/groups/identity-gateway/modules/ecs-task/main.tf
@@ -10,8 +10,10 @@ data "template_file" "container_definitions" {
     application_host          = var.application_host
     fidc_fqdn                 = var.fidc_fqdn
     fidc_realm                = var.fidc_realm
+    fidc_login_journey        = var.fidc_login_journey
     oidc_client_id            = var.oidc_client_id
     oidc_client_secret        = var.oidc_client_secret
+    ui_login_url              = var.ui_login_url
   }
 }
 

--- a/terraform/groups/identity-gateway/modules/ecs-task/templates/container_definitions.json.tpl
+++ b/terraform/groups/identity-gateway/modules/ecs-task/templates/container_definitions.json.tpl
@@ -16,12 +16,20 @@
         "value": "${fidc_realm}"
       },
       {
+        "name": "FIDC_LOGIN_JOURNEY",
+        "value": "${fidc_login_journey}"
+      },
+      {
         "name": "OIDC_CLIENT_ID",
         "value": "${oidc_client_id}"
       },
       {
         "name": "OIDC_CLIENT_SECRET",
         "value": "${oidc_client_secret}"
+      },
+      {
+        "name": "UI_LOGIN_URL",
+        "value": "${ui_login_url}"
       }
     ],
     "portMappings": [

--- a/terraform/groups/identity-gateway/modules/ecs-task/variables.tf
+++ b/terraform/groups/identity-gateway/modules/ecs-task/variables.tf
@@ -66,11 +66,19 @@ variable "fidc_realm" {
   type = string
 }
 
+variable "fidc_login_journey" {
+  type = string
+}
+
 variable "oidc_client_id" {
   type = string
 }
 
 variable "oidc_client_secret" {
+  type = string
+}
+
+variable "ui_login_url" {
   type = string
 }
 

--- a/terraform/groups/identity-gateway/variables.tf
+++ b/terraform/groups/identity-gateway/variables.tf
@@ -81,6 +81,12 @@ variable "fidc_realm" {
   default     = "alpha"
 }
 
+variable "fidc_login_journey" {
+  type        = string
+  description = "ForgeRock Identity Cloud Login Journey"
+  default     = "CHWebFiling"
+}
+
 variable "oidc_client_id" {
   type        = string
   description = "ForgeRock Identity Cloud client ID"
@@ -90,4 +96,8 @@ variable "oidc_client_id" {
 variable "oidc_client_secret" {
   type        = string
   description = "Client secret for the above client"
+}
+
+variable "ui_login_url" {
+  type = string
 }

--- a/webfiling/config/routes/10-webfiling.json.tpl
+++ b/webfiling/config/routes/10-webfiling.json.tpl
@@ -69,6 +69,20 @@
           }
         },
         {
+          "name": "AuthRedirectFilter",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "authRedirect.groovy",
+            "args": {
+              "routeArgAuthUri": "&{ui.login.url}",
+              "routeArgRealm": "&{fidc.realm}",
+              "routeArgJourney": "&{fidc.login.journey}",
+              "routeArgFidcFqdn": "&{fidc.fqdn}"
+            }
+          }
+        },
+        {
           "name": "OAuth2ClientFilter-FIDC",
           "type": "OAuth2ClientFilter",
           "config": {
@@ -109,6 +123,19 @@
                     "/com-logout?silent=1"
                   ]
                 }
+              }
+            }
+          }
+        },
+        {
+          "type": "ConditionalFilter",
+          "config": {
+            "condition": "${matches(request.uri.path, '^/file-for-another-company')}",
+            "delegate": {
+              "type": "StaticRequestFilter",
+              "config": {
+                "method": "GET",
+                "uri": "https://{APPLICATION_HOST}/com-logout?silent=1&endSession=0"
               }
             }
           }

--- a/webfiling/scripts/groovy/authRedirect.groovy
+++ b/webfiling/scripts/groovy/authRedirect.groovy
@@ -1,0 +1,15 @@
+// Redirect to the FIDC authorize endpoint, change it to a journey with a goto URL of the authz request, and force authentication
+
+next.handle(context, request).thenOnResult(response -> {
+   def locationHeaders
+   def locationUri
+
+    if (response.getStatus().isRedirection() &&
+        (locationHeaders = response.headers.get("Location")) != null  &&
+        (locationUri = locationHeaders.firstValue.toString()) ==~ "^https://" + routeArgFidcFqdn + "/am/oauth2/authorize.*") {
+
+       def newUri = routeArgAuthUri + "?goto=" + URLEncoder.encode(locationUri) + "&realm=/" + routeArgRealm + "&service=" + routeArgJourney + "&authIndexType=service&authIndexValue=" + routeArgJourney + "&mode=AUTHN_ONLY&ForceAuth=true"
+       response.headers.remove("Location")
+       response.headers.add("Location",newUri)
+   }
+})


### PR DESCRIPTION
New filters:
- `/file-for-another-company` will redirect to trigger partial logout
- `/authorize` requests will redirect the UI using `ForceAuth=true` and the authorze request as the goto.