### PR TITLE
chore: redirect to logout on oauth2 filter failure

### DIFF
--- a/webfiling/config/routes/10-webfiling.json.tpl
+++ b/webfiling/config/routes/10-webfiling.json.tpl
@@ -114,13 +114,12 @@
                     "failureHandler": {
                       "type": "StaticResponseHandler",
                       "config": {
-                        "status": 500,
+                        "status": 302,
                         "headers": {
-                          "Content-Type": [
-                            "text/plain"
+                          "Location": [
+                            "/oidc/logout"
                           ]
-                        },
-                        "entity": "Error in OAuth 2.0 setup."
+                        }
                       }
                     },
                     "registrations": [


### PR DESCRIPTION
Handle IG session timeout by setting the lifetime of the access token and redirecting to /oidc/logout on error.