### PR TITLE
Resolve IG inconsistency between local and deployed IG instances

### DIFF
--- a/webfiling/config/routes/10-webfiling.json
+++ b/webfiling/config/routes/10-webfiling.json
@@ -171,7 +171,7 @@
                 {
                   "type": "ConditionalFilter",
                   "config": {
-                    "condition": "${matches(request.uri.path, '^/file-for-another-company') or matches(request.uri.path, '^/manage-your-account') or matches(request.uri.path, '^/your-company-list')}",
+                    "condition": "${matches(request.uri.path, '^/file-for-another-company')}",
                     "delegate": {
                       "type": "StaticRequestFilter",
                       "config": {
@@ -194,7 +194,7 @@
                         ],
                         "add": {
                           "location": [
-                            "/oidc/logout?goto=${urlEncode('https://&{ig.host}:443//seclogin?')}${urlEncode(request.uri.query)}"
+                            "/oidc/logout?goto=${urlEncode('https://&{ig.host}//seclogin?')}${urlEncode(request.uri.query)}"
                           ]
                         }
                       }

--- a/webfiling/scripts/groovy/authRedirect.groovy
+++ b/webfiling/scripts/groovy/authRedirect.groovy
@@ -9,29 +9,6 @@ next.handle(context, request).thenOnResult(response -> {
     println("[CHLOG][AUTHREDIRECT] Request URI (Str) : " + request.uri.toString())
     println()
 
-    if (request.uri != null) {
-
-        if (request.uri.toString().endsWith("/manage-your-account")) {
-
-           println("[CHLOG][AUTHREDIRECT] Setting gotoTarget as : " + routeArgManagePath)
-           session["gotoTarget"] = routeArgManagePath
-
-        } else if (request.uri.toString().endsWith("/your-company-list")) {
-
-           println("[CHLOG][AUTHREDIRECT] Setting gotoTarget as : " + routeArgCompaniesPath)
-           session["gotoTarget"] = routeArgCompaniesPath
-
-       } else if (request.uri.toString().endsWith("/file-for-another-company") ||
-                  request.uri.toString().endsWith("/file-for-a-company")) {
-
-            println("[CHLOG][AUTHREDIRECT] Clearing gotoTarget in session")
-            session["gotoTarget"] = ""
-
-        }
-
-        println("[CHLOG][AUTHREDIRECT] Session gotoTarget = " + session["gotoTarget"])
-    }
-
     if (response.getStatus().isRedirection() &&
         (locationHeaders = response.headers.get("Location")) != null &&
         (locationUri = locationHeaders.firstValue.toString()) ==~ "^https://" + routeArgFidcFqdn + "/am/oauth2/authorize.*") {
@@ -59,21 +36,6 @@ next.handle(context, request).thenOnResult(response -> {
 
         // Redirect to landing page using login journey
         newUri += "?realm=/" + routeArgRealm + "&service=" + routeArgLoginJourney + "&authIndexType=service&authIndexValue=" + routeArgLoginJourney
-
-        println()
-        println("[CHLOG][AUTHREDIRECT] Session Goto Target = " + session["gotoTarget"])
-        println()
-
-        if (session["gotoTarget"] != null) {
-
-            if (session["gotoTarget"].equals(routeArgManagePath) ||
-                session["gotoTarget"].equals(routeArgCompaniesPath)) {
-
-                println ("[CHLOG][AUTHREDIRECT] Going to " + session["gotoTarget"])
-                newUri += "&goto=" + URLEncoder.encode(session["gotoTarget"], "utf-8")
-
-            }
-        }
 
         println()
         println("[CHLOG][AUTHREDIRECT] NewURI : " + newUri)

--- a/webfiling/scripts/groovy/start.groovy
+++ b/webfiling/scripts/groovy/start.groovy
@@ -6,7 +6,7 @@ println("[CHLOG][START] Session = " + session)
 println("[CHLOG][START] Session JSON = " + groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(session)))
 println()
 
-if (session && session["oauth2:https://" + igHost + ":443/oidc"] && session["oauth2:https://" + igHost + ":443/oidc"].atr && session["oauth2:https://" + igHost + ":443/oidc"].atr.id_token) {
+if (session && session["oauth2:https://" + igHost + "/oidc"] && session["oauth2:https://" + igHost + "/oidc"].atr && session["oauth2:https://" + igHost + "/oidc"].atr.id_token) {
   location = "/com-logout?silent=1&companySelect=1"
 }
 


### PR DESCRIPTION
* Remove :443 from scripts and filter chains to ensure consistency when checking for tokens and/or URLs
* Remove all prior code added for defining additional URLs for EWF to call to force a logout (to overcome this issue)