### PR TITLE
idam-1051/stop legacy path element being duplicated

### DIFF
--- a/webfiling/scripts/groovy/legacyRewriteHost.groovy
+++ b/webfiling/scripts/groovy/legacyRewriteHost.groovy
@@ -18,7 +18,14 @@ next.handle(context, request).thenOnResult(response -> {
             (locationHeaders = response.headers.get("Location")) != null &&
             (locationUri = locationHeaders.firstValue.toString()) ==~ "^https://${hostPrefix}.*")) {
 
-        newUri = locationUri.replaceAll(hostPrefix, legacyHostPrefix)
+        logger.info('[CHLOG][LEGACYREWRITEHOST] LocationUri : ' + locationUri)
+
+        if (locationUri.indexOf(legacyHostPrefix + '.') == -1) {
+            logger.info('[CHLOG][LEGACYREWRITEHOST] Replacing "' + hostPrefix + '" with "' + legacyHostPrefix + '" in : ' + locationUri)
+            newUri = locationUri.replaceAll(hostPrefix, legacyHostPrefix)
+        } else {
+            newUri = locationUri;
+        }
 
         logger.info("[CHLOG][LEGACYREWRITEHOST] Replaced URI (Location) : " + newUri)
 


### PR DESCRIPTION
* Only replace the kermit URL with the kermit-legacy domain if it doesn't already contain the legacy domain name