### PR TITLE
Allow application access in Dev

### DIFF
--- a/terraform/groups/ewf/locals.tf
+++ b/terraform/groups/ewf/locals.tf
@@ -18,4 +18,8 @@ locals {
     "167.98.200.192/27",
     "195.95.131.0/24"
   ]
+
+  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs) : local.public_allow_cidr_blocks
+  subnet_ids          = var.internal_access_only ? data.aws_subnet_ids.data_subnets.ids : data.aws_subnet_ids.public_subnets.ids
+
 }

--- a/terraform/groups/ewf/main.tf
+++ b/terraform/groups/ewf/main.tf
@@ -42,8 +42,8 @@ module "lb" {
   service_name          = "forgerock-ig"
   vpc_id                = data.aws_vpc.vpc.id
   internal              = var.internal_access_only
-  ingress_cidr_blocks   = var.internal_access_only ? values(data.vault_generic_secret.internal_cidrs.data) : local.public_allow_cidr_blocks
-  subnet_ids            = var.internal_access_only ? data.aws_subnet_ids.data_subnets.ids : data.aws_subnet_ids.public_subnets.ids
+  ingress_cidr_blocks   = local.ingress_cidr_blocks
+  subnet_ids            = local.subnet_ids
   target_port           = 8080
   domain_name           = var.domain_name
   create_route53_record = var.create_route53_record

--- a/terraform/groups/ewf/profiles/heritage-development-eu-west-2/development/vars
+++ b/terraform/groups/ewf/profiles/heritage-development-eu-west-2/development/vars
@@ -10,3 +10,8 @@ autoscaling_min = 2
 autoscaling_max = 4
 target_cpu = 50
 target_memory = 50
+internal_access_cidrs = [
+  "10.254.1.0/24",
+  "10.254.2.0/24",
+  "10.254.3.0/24"
+]

--- a/terraform/groups/ewf/profiles/heritage-development-eu-west-2/development/vars
+++ b/terraform/groups/ewf/profiles/heritage-development-eu-west-2/development/vars
@@ -11,6 +11,7 @@ autoscaling_max = 4
 target_cpu = 50
 target_memory = 50
 internal_access_cidrs = [
+  "10.75.0.0/16",
   "10.254.1.0/24",
   "10.254.2.0/24",
   "10.254.3.0/24"

--- a/terraform/groups/ewf/variables.tf
+++ b/terraform/groups/ewf/variables.tf
@@ -183,6 +183,12 @@ variable "target_memory" {
   description = "Autoscaling: Target Memory usage percentage"
 }
 
+variable "internal_access_cidrs" {
+  type        = list(any)
+  description = "List of additional CIDRs for internal access"
+  default     = []
+}
+
 variable "internal_access_only" {
   type        = bool
   description = "Should the Load Balancer be internal"


### PR DESCRIPTION
Added new `internal_access_cidrs` list var to define a list of CIDRs
Moved computation of `ingress_cidr_blocks` and `subnet_ids` in to locals and updated module to use local vars
Updated `ingress_cidr_blocks` local var to additionally include `internal_access_cidrs` when deploying internal
Populated `internal_access_cidrs` for dev account