### PR TITLE
Updated Staging LB Access for NAT GWs

### DIFF
--- a/terraform/groups/ewf/locals.tf
+++ b/terraform/groups/ewf/locals.tf
@@ -19,7 +19,7 @@ locals {
     "195.95.131.0/24"
   ]
 
-  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs) : local.public_allow_cidr_blocks
+  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs) : concat(local.public_allow_cidr_blocks, var.internal_access_cidrs)
   subnet_ids          = var.internal_access_only ? data.aws_subnet_ids.data_subnets.ids : data.aws_subnet_ids.public_subnets.ids
 
 }

--- a/terraform/groups/ewf/profiles/heritage-staging-eu-west-2/staging/vars
+++ b/terraform/groups/ewf/profiles/heritage-staging-eu-west-2/staging/vars
@@ -11,3 +11,10 @@ autoscaling_max = 4
 target_cpu = 50
 target_memory = 50
 internal_access_only = false
+internal_access_cidrs = [
+  "10.172.116.0/22",
+  "10.65.0.0/16",
+  "35.177.1.77/32",
+  "18.135.80.40/32",
+  "18.135.67.249/32",
+]


### PR DESCRIPTION
Updated `ingress_cidr_blocks` local to include `internal_access_cidrs` var for non-internal LBs
Populated `internal_access_cidrs` for Staging to include manually-added resources

Ref: INC0329860