### PR TITLE
Add external cidr range to terraform

### DIFF
--- a/terraform/groups/ewf/locals.tf
+++ b/terraform/groups/ewf/locals.tf
@@ -6,7 +6,7 @@ locals {
     Team           = "amido"
   }
 
-  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs) : concat(values(data.vault_generic_secret.external_cidrs.data), var.external_cidrs)
+  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs) : concat(values(data.vault_generic_secret.external_cidrs.data), var.internal_access_cidrs)
   subnet_ids          = var.internal_access_only ? data.aws_subnet_ids.data_subnets.ids : data.aws_subnet_ids.public_subnets.ids
 
 }

--- a/terraform/groups/ewf/locals.tf
+++ b/terraform/groups/ewf/locals.tf
@@ -5,21 +5,8 @@ locals {
     ServiceSubType = var.service_name
     Team           = "amido"
   }
-  public_allow_cidr_blocks = [
-    "194.75.36.0/24",
-    "62.254.241.64/26",
-    "5.148.32.192/26",
-    "5.148.69.16/28",
-    "31.221.110.80/29",
-    "154.51.64.64/27",
-    "154.51.128.224/27",
-    "167.98.1.160/28",
-    "167.98.25.176/28",
-    "167.98.200.192/27",
-    "195.95.131.0/24"
-  ]
 
-  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs) : concat(local.public_allow_cidr_blocks, var.internal_access_cidrs)
+  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs) : concat(values(data.vault_generic_secret.external_cidrs.data), var.external_cidrs)
   subnet_ids          = var.internal_access_only ? data.aws_subnet_ids.data_subnets.ids : data.aws_subnet_ids.public_subnets.ids
 
 }

--- a/terraform/groups/ewf/main.tf
+++ b/terraform/groups/ewf/main.tf
@@ -28,7 +28,7 @@ data "vault_generic_secret" "internal_cidrs" {
 }
 
 data "vault_generic_secret" "external_cidrs" {
-  path = "applications/heritage-development-eu-west-2/forgerock/ewf/forgerock-identity-gateway"
+  path = "applications/heritage-${var.environment}-eu-west-2/forgerock/ewf/forgerock-identity-gateway"
 }
 
 ###

--- a/terraform/groups/ewf/main.tf
+++ b/terraform/groups/ewf/main.tf
@@ -27,6 +27,10 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "external_cidrs" {
+  path = "applications/heritage-development-eu-west-2/forgerock/ewf/forgerock-identity-gateway"
+}
+
 ###
 # Modules
 ###


### PR DESCRIPTION
Adds the external cidrs to terraform code.

The external cidrs have been added to vault. The list was provided by Amido (Steve). 