### PR TITLE
Optionally allow access from Test subnets

### DIFF
--- a/terraform/groups/ewf/locals.tf
+++ b/terraform/groups/ewf/locals.tf
@@ -5,8 +5,10 @@ locals {
     ServiceSubType = var.service_name
     Team           = "amido"
   }
+  test_cidr_blocks = var.test_access_enable ? jsondecode(data.vault_generic_secret.test_cidrs.data["cidrs"]) : []
 
-  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs) : concat(jsondecode(data.vault_generic_secret.external_cidrs.data["external_cidrs"]), var.internal_access_cidrs)
+  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs, local.test_cidr_blocks) : concat(jsondecode(data.vault_generic_secret.external_cidrs.data["external_cidrs"]), var.internal_access_cidrs)
   subnet_ids          = var.internal_access_only ? data.aws_subnet_ids.data_subnets.ids : data.aws_subnet_ids.public_subnets.ids
+
 
 }

--- a/terraform/groups/ewf/main.tf
+++ b/terraform/groups/ewf/main.tf
@@ -31,6 +31,10 @@ data "vault_generic_secret" "external_cidrs" {
   path = "applications/heritage-${var.environment}-eu-west-2/forgerock/ewf/forgerock-identity-gateway"
 }
 
+data "vault_generic_secret" "test_cidrs" {
+  path = "aws-accounts/network/shared-services/test_cidr_ranges"
+}
+
 ###
 # Modules
 ###

--- a/terraform/groups/ewf/profiles/heritage-development-eu-west-2/development/vars
+++ b/terraform/groups/ewf/profiles/heritage-development-eu-west-2/development/vars
@@ -18,3 +18,4 @@ internal_access_cidrs = [
 ]
 ig_jvm_args = "-Xms256m -Xmx2048m -Xlog:gc*=warning:stdout -XX:+UseG1GC"
 root_log_level = "DEBUG"
+test_access_enable = true

--- a/terraform/groups/ewf/variables.tf
+++ b/terraform/groups/ewf/variables.tf
@@ -209,3 +209,9 @@ variable "ig_jvm_args" {
 variable "root_log_level" {
   type        = string
 }
+
+variable "test_access_enable" {
+  type        = bool
+  description = "Controls whether access from the Test subnets is required (true) or not (false)"
+  default     = false
+}


### PR DESCRIPTION
Added data lookup for test subnet CIDRs
Added boolean var to optionally allow access from test subnet CIDRs
Updated locals to conditionally include the test CIDRs when internal-only is configured

Resolves: INC0350290