### PR TITLE
Enable container insights

### DIFF
--- a/terraform/groups/chs/modules/ecs/main.tf
+++ b/terraform/groups/chs/modules/ecs/main.tf
@@ -4,6 +4,11 @@
 resource "aws_ecs_cluster" "ig" {
   name = var.service_name
 
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
   tags = var.tags
 }
 

--- a/terraform/groups/ewf/modules/ecs/main.tf
+++ b/terraform/groups/ewf/modules/ecs/main.tf
@@ -4,6 +4,11 @@
 resource "aws_ecs_cluster" "ig" {
   name = var.service_name
 
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
Enabling container insights for the ECS cluster to enable Managed Services to monitor metrics and set up alarms