### PR TITLE
 add to fix from ewf routing issue

### DIFF
--- a/webfiling/scripts/groovy/authRedirect.groovy
+++ b/webfiling/scripts/groovy/authRedirect.groovy
@@ -164,6 +164,7 @@ next.handle(context, request).thenOnResult(response -> {
         }
 
         // Redirect to landing page using login journey
+        newUri = routeArgLoginJourney=="CHWebFiling-Login" ? newUri.split('account/login')[0] : newUri
         newUri += "?realm=/" + routeArgRealm + "&service=" + routeArgLoginJourney +
                 "&authIndexType=service&authIndexValue=" + routeArgLoginJourney
 


### PR DESCRIPTION
WHAT
• EWF (https://ewf.companieshouse.gov.uk/) does not redirect to IDAM start page 
WHY
• Forgerock identity gateway handles it that way and needed to be changed
HOW
• Forgerock identity gateway is updated to redirect to start page if and only if routeArgLoginJourney=="CHWebFiling-Login" which is the target route.