### PR TITLE
add to route correctly on sign out

### DIFF
--- a/webfiling/scripts/groovy/authRedirect.groovy
+++ b/webfiling/scripts/groovy/authRedirect.groovy
@@ -164,18 +164,19 @@ next.handle(context, request).thenOnResult(response -> {
         }
 
         // Redirect to landing page using login journey
-        logger.info("routeArgLoginJourney=>>>>>>>1 " + routeArgLoginJourney)
-        logger.info("newUri=>>>>>>>2 " + newUri)
-
+        logger.info("NEWURI=>>>>>>>1-ROUTE ARG LOGIN JOURNEY VALUE" + routeArgLoginJourney)
+        logger.info("NEWURI=>>>>>>>2-NEWURI VALUE" + newUri)  
+        
         newUri += "?realm=/" + routeArgRealm + "&service=" + routeArgLoginJourney +
                 "&authIndexType=service&authIndexValue=" + routeArgLoginJourney
 
+        def storedNewUri = newUri
         def newUriParam = newUri.split("authIndexValue=")[1]
 
         newUri = newUriParam=="CHWebFiling-Login" && routeArgLoginJourney=="CHWebFiling-Login" ? newUri.split('account/login')[0] : newUri
         
-        logger.info("newUri=>>>>>>>3 " + newUri)
-
+        logger.info("NEWURI=>>>>>>>3-IMMEDIATELY AFTER RERTOUTING FROM EWF" + newUri)  
+        
         logger.info("[CHLOG][AUTHREDIRECT] Session Goto Target = " + session["gotoTarget"])
 
         if (session["gotoTarget"] != null) {
@@ -201,11 +202,13 @@ next.handle(context, request).thenOnResult(response -> {
         // ADDING LANGUAGE TO THE URI
         if (session["ewfLanguage"] != null && session["ewfLanguage"] != "") {
             logger.info("[CHLOG][AUTHREDIRECT][LANGUAGE] Session before redirecting to IDAM UI : " + session["ewfLanguage"])
+            newUri = storedNewUri
             newUri += "&lang=" + URLEncoder.encode((String) session["ewfLanguage"], "utf-8")
+            logger.info("NEWURI=>>>>>>>5-AFTER ADDING LANG " + newUri)  
         }
 
         response.headers.remove("Location")
-        logger.info("newUri=>>>>>>>4 " + newUri)
+        logger.info("NEWURI TO GO TO HEADERS=>>>>>>>4 " + newUri)
         response.headers.add("Location", newUri)
 
     } else {


### PR DESCRIPTION
WHAT  
Currently coming from EWF domain fails when users sign out  
WHY  
In order for the login from EWF to pass the url was processed to remove unwanted parameters.
HOW  
Removed parameters are being restored at sign out to enable it to pass.