### PR TITLE
added ssl_policy for ig load balancers

### DIFF
--- a/terraform/groups/chs/main.tf
+++ b/terraform/groups/chs/main.tf
@@ -47,6 +47,7 @@ module "ecs" {
 module "internal_lb" {
   source                = "./modules/loadbalancing"
   service_name          = "forgerock-ig-internal"
+  alb_ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   internal              = true
   vpc_id                = data.aws_vpc.vpc.id
   ingress_cidr_blocks   = ["0.0.0.0/0"]
@@ -63,6 +64,7 @@ module "internal_lb" {
 module "external_lb" {
   source                = "./modules/loadbalancing"
   service_name          = "forgerock-ig-external"
+  alb_ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   internal              = false
   vpc_id                = data.aws_vpc.vpc.id
   ingress_cidr_blocks   = local.public_allow_cidr_blocks

--- a/terraform/groups/chs/modules/loadbalancing/main.tf
+++ b/terraform/groups/chs/modules/loadbalancing/main.tf
@@ -74,6 +74,7 @@ resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.main.arn
   port              = 443
   protocol          = "HTTPS"
+  ssl_policy        = var.alb_ssl_policy
   certificate_arn   = var.create_certificate && var.internal == true ? aws_acm_certificate_validation.certificate.0.certificate_arn : data.aws_acm_certificate.certificate.0.arn
 
   default_action {

--- a/terraform/groups/chs/modules/loadbalancing/variables.tf
+++ b/terraform/groups/chs/modules/loadbalancing/variables.tf
@@ -50,3 +50,7 @@ variable "tags" {
     Team           = string
   })
 }
+
+variable "alb_ssl_policy" {
+  type    = string
+}

--- a/terraform/groups/ewf/main.tf
+++ b/terraform/groups/ewf/main.tf
@@ -48,6 +48,7 @@ module "ecs" {
 module "lb" {
   source                = "./modules/loadbalancing"
   service_name          = "forgerock-ig"
+  alb_ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   vpc_id                = data.aws_vpc.vpc.id
   internal              = var.internal_access_only
   ingress_cidr_blocks   = local.ingress_cidr_blocks

--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -75,6 +75,7 @@ resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.main.arn
   port              = 443
   protocol          = "HTTPS"
+  ssl_policy        = var.alb_ssl_policy
   certificate_arn   = var.create_certificate ? aws_acm_certificate_validation.certificate.0.certificate_arn : data.aws_acm_certificate.certificate.0.arn
 
   default_action {

--- a/terraform/groups/ewf/modules/loadbalancing/variables.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/variables.tf
@@ -50,3 +50,7 @@ variable "tags" {
     Team           = string
   })
 }
+
+variable "alb_ssl_policy" {
+  type    = string
+}


### PR DESCRIPTION
# Add SSL Policy to IG load balancers

Currently the Forgerock IG load balancers have a default SSL policy (`ELBSecurityPolicy-2016-08`) which allows TLS 1.0. 
This is because there is no policy defined for the load balancer listeners in the Terraform code. 

I have added the config for the SLL Policy into the terraform and set the policy to be `ELBSecurityPolicy-TLS13-1-2-2021-06` which does not allow for TLS1.0. 

The reason for doing this is to ensure that TLS1.0 is no longer supported by the load balancers, that version of TLS having been deemed insecure. 

Here is the AWS documentation that explains the changes I have made:  
[Create an HTTPS listener for your Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html)

Here is the Terraform provider documentation: 
[Resource: aws_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/3.0.0/docs/resources/lb_listener#argument-reference)

