### PR TITLE
Adding iboss cidrs for ewf staging

### DIFF
--- a/terraform/groups/ewf/locals.tf
+++ b/terraform/groups/ewf/locals.tf
@@ -6,9 +6,9 @@ locals {
     Team           = "amido"
   }
   test_cidr_blocks = var.test_access_enable ? jsondecode(data.vault_generic_secret.test_cidrs.data["cidrs"]) : []
+  iboss_cidr_blocks = var.iboss_access_enable ? jsondecode(data.vault_generic_secret.iboss_cidrs.data["iboss_cidrs"]) : []
 
-  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs, local.test_cidr_blocks) : concat(jsondecode(data.vault_generic_secret.external_cidrs.data["external_cidrs"]), var.internal_access_cidrs)
+  ingress_cidr_blocks = var.internal_access_only ? concat(values(data.vault_generic_secret.internal_cidrs.data), var.internal_access_cidrs, local.test_cidr_blocks) : concat(jsondecode(data.vault_generic_secret.external_cidrs.data["external_cidrs"]), var.internal_access_cidrs, local.iboss_cidr_blocks)
   subnet_ids          = var.internal_access_only ? data.aws_subnet_ids.data_subnets.ids : data.aws_subnet_ids.public_subnets.ids
-
 
 }

--- a/terraform/groups/ewf/main.tf
+++ b/terraform/groups/ewf/main.tf
@@ -27,6 +27,10 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "iboss_cidrs" {
+  path = "aws-accounts/network/iboss"
+}
+
 data "vault_generic_secret" "external_cidrs" {
   path = "applications/heritage-${var.environment}-eu-west-2/forgerock/ewf/forgerock-identity-gateway"
 }

--- a/terraform/groups/ewf/profiles/heritage-staging-eu-west-2/staging/vars
+++ b/terraform/groups/ewf/profiles/heritage-staging-eu-west-2/staging/vars
@@ -20,3 +20,4 @@ internal_access_cidrs = [
 ]
 ig_jvm_args = "-Xms256m -Xmx3072m -Xlog:gc*=warning:stdout -XX:+UseG1GC"
 root_log_level = "WARN"
+iboss_access_enable = true

--- a/terraform/groups/ewf/variables.tf
+++ b/terraform/groups/ewf/variables.tf
@@ -216,6 +216,11 @@ variable "test_access_enable" {
   default     = false
 }
 
+variable "iboss_access_enable" {
+  type        = bool
+  description = "Controls whether access from the iboss access is required (true) or not (false)"
+  default     = false
+}
 variable "alerting_email_address" {
   type = string
 }


### PR DESCRIPTION
Adding iboss cidrs for ewf staging. These have already been added manually. 
iboss_access_enable has been added as a bool to follow the conversation and to give the flexibility.