### PR TITLE
change resource block for security groups

### DIFF
--- a/terraform/groups/ewf/variables.tf
+++ b/terraform/groups/ewf/variables.tf
@@ -207,7 +207,7 @@ variable "ig_jvm_args" {
 }
 
 variable "root_log_level" {
-  type        = string
+  type = string
 }
 
 variable "test_access_enable" {


### PR DESCRIPTION
Based on the Terraform Provider docs here:
https://registry.terraform.io/providers/hashicorp/aws/5.99.0/docs/resources/vpc_security_group_egress_rule

We have updated the resource block used for security group rules from `aws_security_group_rule` to `aws_vpc_security_group_ingress_rule`

