### PR TITLE
Create security group before destroying

### DIFF
--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -120,6 +120,10 @@ resource "aws_security_group" "lb" {
   name        = "${var.service_name}-sg"
   vpc_id      = var.vpc_id
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
## WHAT
Create a new security group before replacing a resource

## WHY
Terraform cannot delete the security group because it is attached to resources
```
The following security groups can't be deleted. They are either default security groups, referenced by other security groups, or they are associated with instances or network interfaces.
```

## HOW 
Add a parameter `create_before_destroy = true`