### PR TITLE
Clone security group forgerock-ig-lb

### DIFF
--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -120,6 +120,10 @@ resource "aws_security_group" "lb" {
   name        = "${var.service_name}-sg"
   vpc_id      = var.vpc_id
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = var.tags
 }
 

--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -50,7 +50,7 @@ resource "aws_lb" "main" {
   enable_cross_zone_load_balancing = "true"
   internal                         = var.internal
   subnets                          = var.subnet_ids
-  security_groups                  = [aws_security_group.lb.id]
+  security_groups                  = [aws_security_group.main.id]
   enable_deletion_protection       = "true"
 
   access_logs {
@@ -115,7 +115,20 @@ resource "aws_lb_target_group" "main" {
   tags = var.tags
 }
 
+# Old security group - to be deleted
 resource "aws_security_group" "lb" {
+  description = "Restricts access to the load balancer"
+  name        = "${var.service_name}-lb"
+  vpc_id      = var.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_security_group" "main" {
   description = "Restricts access to the load balancer"
   name        = "${var.service_name}-sg"
   vpc_id      = var.vpc_id
@@ -130,7 +143,7 @@ resource "aws_security_group" "lb" {
 resource "aws_vpc_security_group_egress_rule" "all" {
   description = "Allow outbound traffic"
 
-  security_group_id = aws_security_group.lb.id
+  security_group_id = aws_security_group.main.id
 
   from_port   = 0
   to_port     = 0
@@ -141,7 +154,7 @@ resource "aws_vpc_security_group_egress_rule" "all" {
 resource "aws_vpc_security_group_ingress_rule" "all_80" {
   for_each = toset(var.ingress_cidr_blocks)
 
-  security_group_id = aws_security_group.lb.id
+  security_group_id = aws_security_group.main.id
 
   cidr_ipv4   = each.value
   from_port   = 80
@@ -152,7 +165,7 @@ resource "aws_vpc_security_group_ingress_rule" "all_80" {
 resource "aws_vpc_security_group_ingress_rule" "all_443" {
   for_each = toset(var.ingress_cidr_blocks)
 
-  security_group_id = aws_security_group.lb.id
+  security_group_id = aws_security_group.main.id
 
   cidr_ipv4   = each.value
   from_port   = 443

--- a/terraform/groups/ewf/modules/loadbalancing/outputs.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/outputs.tf
@@ -3,5 +3,5 @@ output "target_group_arn" {
 }
 
 output "security_group_id" {
-  value = aws_security_group.lb.id
+  value = aws_security_group.main.id
 }


### PR DESCRIPTION
## WHAT
Clone security group forgerock-ig-lb

## WHY
We cannot delete the old security group until it has been detached from running resources. We should create the replacement first, ensure it is connected properly, and create a separate code change to remove the original group

## HOW
Define new security group as a separate resource block `aws_security_group.main`