### PR TITLE
Fix typo

### DIFF
--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -130,7 +130,7 @@ resource "aws_security_group" "lb" {
 
 resource "aws_security_group" "main" {
   description = "Restricts access to the load balancer"
-  name        = "${var.service_name}-sg"
+  name        = "${var.service_name}-lb-sg"
   vpc_id      = var.vpc_id
 
   lifecycle {


### PR DESCRIPTION
Fix typo - don't use the same name as an existing security group.