### PR TITLE
Delete old lb security group

### DIFF
--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -115,27 +115,10 @@ resource "aws_lb_target_group" "main" {
   tags = var.tags
 }
 
-# Old security group - to be deleted
-resource "aws_security_group" "lb" {
-  description = "Restricts access to the load balancer"
-  name        = "${var.service_name}-lb"
-  vpc_id      = var.vpc_id
-
-  lifecycle {
-    create_before_destroy = true
-  }
-
-  tags = var.tags
-}
-
 resource "aws_security_group" "main" {
   description = "Restricts access to the load balancer"
   name        = "${var.service_name}-lb-sg"
   vpc_id      = var.vpc_id
-
-  lifecycle {
-    create_before_destroy = true
-  }
 
   tags = var.tags
 }


### PR DESCRIPTION
## WHAT 
Delete the old security group 

## WHY
We have cloned the `forgerock-ig-lb` security group to a new resource `forgerock-ig-lb-sg`. The old resource is now ready to be removed

## HOW 
Remove the resource block for `aws_security_group.lb`