### PR TITLE
Fix count attribute in sg rules

### DIFF
--- a/terraform/groups/ewf/main.tf
+++ b/terraform/groups/ewf/main.tf
@@ -149,7 +149,7 @@ resource "aws_vpc_security_group_ingress_rule" "iboss_443" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "vpn_80" {
-  count             = contains(local.iboss_cidr_blocks, "10.172.20.0/22") ? 1 : 0
+  count             = contains(local.iboss_cidr_blocks["iboss_cidrs"], "10.172.20.0/22") ? 0 : 1
   description       = "added manually - iboss vpn"
   security_group_id = module.lb.security_group_id
 
@@ -159,7 +159,7 @@ resource "aws_vpc_security_group_ingress_rule" "vpn_80" {
   ip_protocol = "tcp"
 }
 resource "aws_vpc_security_group_ingress_rule" "vpn_443" {
-  count             = contains(local.iboss_cidr_blocks, "10.172.20.0/22") ? 1 : 0
+  count             = contains(local.iboss_cidr_blocks["iboss_cidrs"], "10.172.20.0/22") ? 0 : 1
   description       = "added manually - IPO vpn"
   security_group_id = module.lb.security_group_id
 


### PR DESCRIPTION
## WHAT
Fix count attribute in sg rules

## WHY
Terraform plan has an error `local.iboss_cidr_blocks is object with 1 attribute "iboss_cidrs"`

## HOW
Ensure we are reading from `local.iboss_cidr_blocks["iboss_cidrs"]`