### PR TITLE
Adjust egress sg rule ports

### DIFF
--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -145,8 +145,6 @@ resource "aws_vpc_security_group_egress_rule" "all" {
 
   security_group_id = aws_security_group.main.id
 
-  from_port   = 0
-  to_port     = 0
   ip_protocol = "-1"
   cidr_ipv4   = "0.0.0.0/0"
 }


### PR DESCRIPTION
## WHAT
Do not define ports on egress rule

## WHY
Use -1 to specify all protocols. Note that if ip_protocol is set to -1, it translates to all protocols, all port ranges, and from_port and to_port values should not be defined