### PR TITLE
dvop-2371 add iboss vpn cidr rules to forgerock-ig-lb

### DIFF
--- a/terraform/groups/ewf/main.tf
+++ b/terraform/groups/ewf/main.tf
@@ -126,7 +126,7 @@ module "ig" {
 
 resource "aws_vpc_security_group_ingress_rule" "iboss_80" {
   for_each    = toset(local.iboss_cidr_blocks["iboss_cidrs"])
-  description = "added manually - iboss vpn"
+  description = "iboss vpn"
 
   security_group_id = module.lb.security_group_id
 
@@ -138,7 +138,7 @@ resource "aws_vpc_security_group_ingress_rule" "iboss_80" {
 
 resource "aws_vpc_security_group_ingress_rule" "iboss_443" {
   for_each    = toset(local.iboss_cidr_blocks["iboss_cidrs"])
-  description = "added manually - iboss vpn"
+  description = "iboss vpn"
 
   security_group_id = module.lb.security_group_id
 

--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -50,7 +50,7 @@ resource "aws_lb" "main" {
   enable_cross_zone_load_balancing = "true"
   internal                         = var.internal
   subnets                          = var.subnet_ids
-  security_groups                  = [aws_security_group.main.id]
+  security_groups                  = [aws_security_group.lb.id]
   enable_deletion_protection       = "true"
 
   access_logs {
@@ -115,26 +115,13 @@ resource "aws_lb_target_group" "main" {
   tags = var.tags
 }
 
-# Old security group - to be deleted
 resource "aws_security_group" "lb" {
   description = "Restricts access to the load balancer"
   name        = "${var.service_name}-lb"
   vpc_id      = var.vpc_id
 
   lifecycle {
-    create_before_destroy = true
-  }
-
-  tags = var.tags
-}
-
-resource "aws_security_group" "main" {
-  description = "Restricts access to the load balancer"
-  name        = "${var.service_name}-lb-sg"
-  vpc_id      = var.vpc_id
-
-  lifecycle {
-    create_before_destroy = true
+    create_before_destroy = false
   }
 
   tags = var.tags
@@ -143,7 +130,7 @@ resource "aws_security_group" "main" {
 resource "aws_vpc_security_group_egress_rule" "all" {
   description = "Allow outbound traffic"
 
-  security_group_id = aws_security_group.main.id
+  security_group_id = aws_security_group.lb.id
 
   ip_protocol = "-1"
   cidr_ipv4   = "0.0.0.0/0"
@@ -152,7 +139,7 @@ resource "aws_vpc_security_group_egress_rule" "all" {
 resource "aws_vpc_security_group_ingress_rule" "all_80" {
   for_each = toset(var.ingress_cidr_blocks)
 
-  security_group_id = aws_security_group.main.id
+  security_group_id = aws_security_group.lb.id
 
   cidr_ipv4   = each.value
   from_port   = 80
@@ -163,7 +150,7 @@ resource "aws_vpc_security_group_ingress_rule" "all_80" {
 resource "aws_vpc_security_group_ingress_rule" "all_443" {
   for_each = toset(var.ingress_cidr_blocks)
 
-  security_group_id = aws_security_group.main.id
+  security_group_id = aws_security_group.lb.id
 
   cidr_ipv4   = each.value
   from_port   = 443

--- a/terraform/groups/ewf/modules/loadbalancing/outputs.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/outputs.tf
@@ -3,5 +3,5 @@ output "target_group_arn" {
 }
 
 output "security_group_id" {
-  value = aws_security_group.main.id
+  value = aws_security_group.lb.id
 }


### PR DESCRIPTION
## WHAT
Add iBoss VPN CIDR rules to forgerock-ig-lb

## WHY
https://companieshouse.atlassian.net/browse/DVOP-2371
Terraform attempts to create rules before they have been removed, leading to a duplicate rule conflict.

## HOW
Update security group rules to use the resource type `aws_vpc_security_group_ingress_rule` and set an attribute `create_before_destroy = false`