### PR TITLE
Enable debug logging in staging

### DIFF
--- a/terraform/groups/ewf/profiles/heritage-staging-eu-west-2/staging/vars
+++ b/terraform/groups/ewf/profiles/heritage-staging-eu-west-2/staging/vars
@@ -19,4 +19,4 @@ internal_access_cidrs = [
   "18.135.67.249/32",
 ]
 ig_jvm_args = "-Xms256m -Xmx3072m -Xlog:gc*=warning:stdout -XX:+UseG1GC"
-root_log_level = "WARN"
+root_log_level = "DEBUG"


### PR DESCRIPTION
## WHAT
Enable debug logging in staging

## WHY
Dev is inaccessible due to security blocking, so we should test in Staging

## HOW
Change log level from WARN to DEBUG