### PR TITLE
Remove forgerock-ig-lb security group

### DIFF
--- a/terraform/groups/ewf/modules/loadbalancing/main.tf
+++ b/terraform/groups/ewf/modules/loadbalancing/main.tf
@@ -115,15 +115,6 @@ resource "aws_lb_target_group" "main" {
   tags = var.tags
 }
 
-# Old security group - to be deleted
-resource "aws_security_group" "lb" {
-  description = "Restricts access to the load balancer"
-  name        = "${var.service_name}-lb"
-  vpc_id      = var.vpc_id
-
-  tags = var.tags
-}
-
 resource "aws_security_group" "main" {
   description = "Restricts access to the load balancer"
   name        = "${var.service_name}-lb-sg"


### PR DESCRIPTION
## WHAT
Remove forgerock-ig-lb security group

## WHY
Replaced by forgerock-ig-lb-sg security group in https://github.com/companieshouse/forgerock-identity-gateway/pull/173

## HOW
Remove resource block for `aws_security_group.lb`